### PR TITLE
Broken commit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub const NAME: &str = "rraval workflow lib";
+pub const NAME: &str = "";
 
 #[cfg(test)]
 mod test {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use rraval_workflows::NAME;
 
 fn main() {
-    println!("main: {}", NAME);
+    let x = 1f32 == f32::NAN;
+    println!("main: {}",
+             NAME);
 }


### PR DESCRIPTION
Purposefully introduces errors to demonstrate that Rust checks catch
mistakes.